### PR TITLE
python-hidapi: Fix FS#67103 (revert hid_get_input_report) and add a check function

### DIFF
--- a/python-hidapi/PKGBUILD
+++ b/python-hidapi/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=python-hidapi
 _pipname=hidapi
 pkgver=0.9.0.3
 _pkgver=${pkgver%.*}.post${pkgver##*.}
-pkgrel=4
+pkgrel=5
 arch=('x86_64')
 pkgdesc="A Cython interface to the hidapi from signal11/hidapi"
 url="https://github.com/trezor/cython-hidapi"
@@ -33,7 +33,7 @@ build() {
 }
 
 package_python-hidapi() {
-  cd $_pipname-$_pkgver
+  cd "$_pipname-$_pkgver"
 
   python setup.py install --root="$pkgdir" --optimize=1 --skip-build \
         --without-libusb --with-system-hidapi
@@ -44,3 +44,9 @@ package_python-hidapi() {
   install -Dm 755 LICENSE-orig.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE-orig.txt
 }
 
+check() {
+  cd "$_pipname-$_pkgver"
+
+  local python_version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+  PYTHONPATH="$PWD/build/lib.linux-$CARCH-${python_version}" python tests.py
+}

--- a/python-hidapi/PKGBUILD
+++ b/python-hidapi/PKGBUILD
@@ -14,8 +14,16 @@ url="https://github.com/trezor/cython-hidapi"
 depends=('python' 'hidapi')
 makedepends=('cython' 'python-setuptools' 'udev')
 license=('custom')
-source=(https://pypi.org/packages/source/${_pipname:0:1}/$_pipname/$_pipname-$_pkgver.tar.gz)
-sha512sums=('606540833459e615a8e50ff3a2c59362dab7d19d42d5e9dc2288c8c8d32e3df7214e758a9814e7de6d26bbdccd76ccf6c652b0bf8ac5b3f46124a9a7b007b971')
+source=("https://pypi.org/packages/source/${_pipname:0:1}/$_pipname/$_pipname-$_pkgver.tar.gz"
+        'revert-hid_get_input_report.patch')
+sha512sums=('606540833459e615a8e50ff3a2c59362dab7d19d42d5e9dc2288c8c8d32e3df7214e758a9814e7de6d26bbdccd76ccf6c652b0bf8ac5b3f46124a9a7b007b971'
+            '717bf0a24196b1c2da90a7928ac7707ff9cdb6010e1998b3bc8129c8ca9233058b6f9197bcf35504d4b0d67b4288f6500dfe805acae48bd9b53c24b6da946d4a')
+
+prepare() {
+  cd "$_pipname-$_pkgver"
+
+  patch --forward --strip=1 --input="${srcdir}/revert-hid_get_input_report.patch"
+}
 
 build() {
   cd "$_pipname-$_pkgver"

--- a/python-hidapi/revert-hid_get_input_report.patch
+++ b/python-hidapi/revert-hid_get_input_report.patch
@@ -1,0 +1,79 @@
+diff --unified --recursive --text package.orig/chid.pxd package.new/chid.pxd
+--- package.orig/chid.pxd	2020-07-05 23:48:53.567649269 -0300
++++ package.new/chid.pxd	2020-07-05 23:49:40.391130648 -0300
+@@ -29,7 +29,6 @@
+   int hid_set_nonblocking(hid_device* device, int value)
+   int hid_send_feature_report(hid_device* device, unsigned char *data, int length) nogil
+   int hid_get_feature_report(hid_device* device, unsigned char *data, int length) nogil
+-  int hid_get_input_report(hid_device* device, unsigned char *data, int length) nogil
+ 
+   int hid_get_manufacturer_string(hid_device*, wchar_t *, size_t)
+   int hid_get_product_string(hid_device*, wchar_t *, size_t)
+diff --unified --recursive --text package.orig/hid.pyx package.new/hid.pyx
+--- package.orig/hid.pyx	2020-07-05 23:48:53.567649269 -0300
++++ package.new/hid.pyx	2020-07-05 23:49:40.391130648 -0300
+@@ -206,30 +206,6 @@
+           free(cbuff)
+       return res
+ 
+-  def get_input_report(self, int report_num, int max_length):
+-      if self._c_hid == NULL:
+-          raise ValueError('not open')
+-      cdef hid_device * c_hid = self._c_hid
+-      cdef unsigned char lbuff[16]
+-      cdef unsigned char* cbuff
+-      cdef size_t c_max_length = max_length
+-      cdef int n
+-      if max_length <= 16:
+-          cbuff = lbuff
+-      else:
+-          cbuff = <unsigned char *>malloc(max_length)
+-      cbuff[0] = report_num
+-      with nogil:
+-          n = hid_get_input_report(c_hid, cbuff, c_max_length)
+-      res = []
+-      if n < 0:
+-          raise IOError('read error')
+-      for i in range(n):
+-          res.append(cbuff[i])
+-      if max_length > 16:
+-          free(cbuff)
+-      return res
+-
+   def error(self):
+       if self._c_hid == NULL:
+           raise ValueError('not open')
+diff --unified --recursive --text package.orig/hidraw.pyx package.new/hidraw.pyx
+--- package.orig/hidraw.pyx	2020-07-05 23:48:53.570982615 -0300
++++ package.new/hidraw.pyx	2020-07-05 23:49:40.391130648 -0300
+@@ -206,30 +206,6 @@
+           free(cbuff)
+       return res
+ 
+-  def get_input_report(self, int report_num, int max_length):
+-      if self._c_hid == NULL:
+-          raise ValueError('not open')
+-      cdef hid_device * c_hid = self._c_hid
+-      cdef unsigned char lbuff[16]
+-      cdef unsigned char* cbuff
+-      cdef size_t c_max_length = max_length
+-      cdef int n
+-      if max_length <= 16:
+-          cbuff = lbuff
+-      else:
+-          cbuff = <unsigned char *>malloc(max_length)
+-      cbuff[0] = report_num
+-      with nogil:
+-          n = hid_get_input_report(c_hid, cbuff, c_max_length)
+-      res = []
+-      if n < 0:
+-          raise IOError('read error')
+-      for i in range(n):
+-          res.append(cbuff[i])
+-      if max_length > 16:
+-          free(cbuff)
+-      return res
+-
+   def error(self):
+       if self._c_hid == NULL:
+           raise ValueError('not open')


### PR DESCRIPTION
The underlying hid_get_input_report API has not yet reached a HIDAPI release, and attempting to wrap it causes an "undefined symbol" when the hid module is imported.

First, revert the upstream changes that add this new method.  In another commit, add a check function and bump pkgrel.

Note: as hidraw.pyx is a symlink in the repository, but a regular file in the sdist that is used in this package, it is not sufficient to use
the patch generated by git revert.

Related: FS#67103 <https://bugs.archlinux.org/task/67103>