### PR TITLE
upgpkg: neofetch 7.1.0-2 - rm unneeded optdepend

### DIFF
--- a/neofetch/.SRCINFO
+++ b/neofetch/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = neofetch
 	pkgdesc = A CLI system information tool written in BASH that supports displaying images.
 	pkgver = 7.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/dylanaraps/neofetch
 	arch = any
 	license = MIT
@@ -13,7 +13,6 @@ pkgbase = neofetch
 	optdepends = jp2a: Display Images
 	optdepends = libcaca: Display Images
 	optdepends = nitrogen: Wallpaper Display
-	optdepends = pacman-contrib: Display package count
 	optdepends = w3m: Display Images
 	optdepends = xdotool: See https://github.com/dylanaraps/neofetch/wiki/Images-in-the-terminal
 	optdepends = xorg-xdpyinfo: Resolution detection (Single Monitor)

--- a/neofetch/PKGBUILD
+++ b/neofetch/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=neofetch
 pkgver=7.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A CLI system information tool written in BASH that supports displaying images."
 arch=('any')
 url="https://github.com/dylanaraps/neofetch"
@@ -18,7 +18,6 @@ optdepends=(
   'jp2a: Display Images'
   'libcaca: Display Images'
   'nitrogen: Wallpaper Display'
-  'pacman-contrib: Display package count'
   'w3m: Display Images'
   'xdotool: See https://github.com/dylanaraps/neofetch/wiki/Images-in-the-terminal'
   'xorg-xdpyinfo: Resolution detection (Single Monitor)'


### PR DESCRIPTION
Per our discussion on Discord:

`neofetch` lists `pacman-contrib` as an optional dependency, but since https://github.com/dylanaraps/neofetch/commit/9175a47a3cd1b7cc2514a47a1db6511700e4bcfe (first included in neofetch v5.0.0) neofetch has not used anything provided by pacman-contrib, and the package count for Arch (and derivatives) is found using only `pacman`.