### PR TITLE
Update python-nbxmpp to 2.0.2, this is required for Gajim 1.3.1

### DIFF
--- a/python-nbxmpp/PKGBUILD
+++ b/python-nbxmpp/PKGBUILD
@@ -3,15 +3,15 @@
 
 pkgname=python-nbxmpp
 pkgdesc="A Python library to use Jabber/XMPP networks in a non-blocking way"
-pkgver=1.0.2
-pkgrel=3
+pkgver=2.0.2
+pkgrel=1
 arch=(any)
 url="https://dev.gajim.org/gajim/python-nbxmpp/"
 license=(GPL3)
 depends=(libsoup python-gobject python-idna python-precis_i18n)
 makedepends=(python-setuptools)
 source=($pkgname-$pkgver.tar.gz::https://dev.gajim.org/gajim/python-nbxmpp/repository/nbxmpp-$pkgver/archive.tar.gz)
-sha256sums=('9de08827210c22e533793440ee201b750a440460f72cb8bdf3e1f15bc31b6b98')
+sha256sums=('40de72ea33812c95a1c759c8e4a417283ea008d098a2390433545b2b47c167cc')
 
 prepare() {
   mv $pkgname-nbxmpp-* $pkgname-$pkgver


### PR DESCRIPTION
PR for Gajim 1.3.1 see https://github.com/anthraxx/arch-pkgbuilds/pull/44