### PR TITLE
tailscale: fix version detection logic

### DIFF
--- a/tailscale/PKGBUILD
+++ b/tailscale/PKGBUILD
@@ -27,7 +27,6 @@ prepare() {
 
 build() {
     cd "${pkgname}"
-    eval "$(./version/version.sh)"
     export CGO_CPPFLAGS="${CPPFLAGS}"
     export CGO_CFLAGS="${CFLAGS}"
     export CGO_CXXFLAGS="${CXXFLAGS}"
@@ -35,9 +34,9 @@ build() {
     export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
     GO_LDFLAGS="\
         -linkmode=external \
-        -X tailscale.com/version.Long=${VERSION_LONG} \
-        -X tailscale.com/version.Short=${VERSION_SHORT} \
-        -X tailscale.com/version.GitCommit=${VERSION_GIT_HASH}"
+        -X tailscale.com/version.Long=${pkgver} \
+        -X tailscale.com/version.Short=$(cut -d+ -f1 <<< "${pkgver}") \
+        -X tailscale.com/version.GitCommit=${_commit}"
     for cmd in ./cmd/tailscale ./cmd/tailscaled; do
         go build -v -tags xversion -ldflags "$GO_LDFLAGS" "$cmd"
     done


### PR DESCRIPTION
A while ago Tailscale switched to using an alternate process to figure
out what version should be compiled into the binary. This approximates
that in a way that should be sufficent for Arch Linux.

Signed-off-by: Christine Dodrill <me@christine.website>