### PR TITLE
new pytoolconfig dependency for python-rope (WIP Solutions)

### DIFF
--- a/python-rope/PKGBUILD
+++ b/python-rope/PKGBUILD
@@ -12,7 +12,17 @@ pkgdesc='Refactoring library'
 arch=('any')
 url='https://github.com/python-rope/rope'
 license=('GPL')
+
+#OPTION 1 depends (add pytoolconfig package as dependency, package needs to be created)
+#depends=('pytoolconfig')
+#OPTION 2 depends
+#depends=('python-pip')
+
 makedepends=('python' 'python-setuptools')
+
+#OPTION 2 (add .install file to install pytoolconfig with pip)
+#install=pkgname.install
+
 source=("https://pypi.io/packages/source/r/rope/rope-$pkgver.tar.gz")
 sha256sums=('4e8ede637d8f43eb83847ef9ea7edbf4ceb9d641deea592ed38a8875cde64265')
 

--- a/python-rope/python-rope.install
+++ b/python-rope/python-rope.install
@@ -1,0 +1,10 @@
+#Don't know if this allowed under Arch Linux ethos
+#This may need to be reformatted or changed in final implementation
+
+#post_install() {
+	#pip install pytoolconfig
+#}
+
+#post_upgrade() {
+	#pip install pytoolconfig --upgrade
+#}


### PR DESCRIPTION
python-rope has a new listed dependency that is currently not available in arch repos
The new dependency as listed in pyproject.toml is "pytoolconfig >= 1.1.2"

Either a new package for pytoolconfig must be made (project listed at https://github.com/bagel897/pytoolconfig)
Or an install script can install pytoolconfig using pip, which I am not sure fits the Arch ethos, but I can't find a clear answer on

A third possible option, is trying to removing the dependency from requires.txt, but that could break things. I am happy to test that idea if requested