### PR TITLE
fzf: Add support for aarch64

### DIFF
--- a/fzf/PKGBUILD
+++ b/fzf/PKGBUILD
@@ -11,7 +11,7 @@ pkgname=fzf
 pkgver=0.34.0
 pkgrel=1
 pkgdesc='Command-line fuzzy finder'
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url='https://github.com/junegunn/fzf'
 license=('MIT')
 depends=('bash')
@@ -37,6 +37,7 @@ build() {
 	export CGO_CXXFLAGS="${CXXFLAGS}"
 	export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
 	make
+	make bin/fzf
 }
 
 check() {
@@ -62,7 +63,7 @@ package() {
 	## Binaries
 	install -dm755 "$pkgdir"/usr/bin
 	install -m755 bin/fzf-tmux "$pkgdir"/usr/bin/
-	install -Dm755 target/fzf-linux_amd64 "$pkgdir"/usr/bin/fzf
+	install -Dm755 bin/fzf "$pkgdir"/usr/bin/fzf
 
 	## Completion and keybindings
 	install -dm755 "$pkgdir"/usr/share/fzf


### PR DESCRIPTION
Use the bin/fzf make target to copy the binary for the current architecture into ./bin/fzf. When packaging, use the file in this well-known path, which results in packaging the binary for the current architecture.

This patch likely results in this package now building on other architectures too.